### PR TITLE
Redirect with 302 instead of 301

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ const handleSearchGiphyUsingTranslate = async ({ params: { query }, res }) => {
     // If it does exist, then redirect the client (appending the image id to the path
     // as we want to persist the image when the URL is shared to others).
     res.setHeader('Location', `/${query}/${imageId}`);
-    return send(res, 301, {});
+    return send(res, 302, {});
   } catch (e) {
     return e;
   }


### PR DESCRIPTION
IMO it makes more sense to redirect using 302 instead of 301 as 301 is cached in the browser, whereas with a 302 the browser makes the request every time.