### PR TITLE
Allow .gif suffix

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ const handleNoSearchQuery = () => {
 
 const handleSearchGiphyUsingTranslate = async ({ params: { query }, res }) => {
   try {
+    query = query.replace(/.gif$/, '');
+
     // Lets search for the image with the query that's given...
     const resp = await request({ uri: GIPHY_TRANSLATE_API_URL, qs: { api_key: API_KEY, s: query }, json: true });
 
@@ -26,7 +28,7 @@ const handleSearchGiphyUsingTranslate = async ({ params: { query }, res }) => {
 
     // If it does exist, then redirect the client (appending the image id to the path
     // as we want to persist the image when the URL is shared to others).
-    res.setHeader('Location', `/${query}/${imageId}`);
+    res.setHeader('Location', `/${query}/${imageId}.gif`);
     return send(res, 301, {});
   } catch (e) {
     return e;
@@ -36,6 +38,8 @@ const handleSearchGiphyUsingTranslate = async ({ params: { query }, res }) => {
 const handleRequestGiphyImage = async ({ params: { imageId }, res }) => {
   // Request the image!
   try {
+    imageId = imageId.replace(/.gif$/, '');
+
     const gif = await request({ uri: giphyGifByIdUrl(imageId), json: true });
     // Prepare the browser for an awesome GIF!
     res.setHeader('Content-Type', 'image/gif');


### PR DESCRIPTION
I tried sending a gif to a friend but the chat application didn't embed the image into the chat because it didn't realize it was a gif because it didn't have the `.gif` file extension.
I was able to hack it by adding [`?.gif`](https://gif.now.sh/cats?.gif) to the end, but I think this PR would make it much nicer :)

This adds support for that so you can load `/cats.gif`, or `/cats/3o7qDPfGhunRMZikI8.gif`.
It also adds the `.gif` file extension to redirects.

Old links still work.