### PR TITLE
Replace micro-api with microrouter

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "fs-promise": "^2.0.0",
     "lodash": "^4.17.4",
     "micro": "^7.3.3",
-    "micro-api": "^0.1.1",
     "micro-cors": "0.0.4",
+    "microrouter": "^2.1.1",
     "request": "^2.80.0",
     "request-promise": "^4.1.1"
   }


### PR DESCRIPTION
I noticed I sometimes got 502 from https://gif.now.sh/, so i took a look at the [logs][logs] and saw a bunch of this error: `Unhandled rejection Error: Can't set headers after they are sent.`

<details><summary>Show stack trace</summary>
  <p>

```
Unhandled rejection Error: Can't set headers after they are sent.
    at validateHeader (_http_outgoing.js:504:11)
    at ServerResponse.setHeader (_http_outgoing.js:511:3)
    at send (/home/nowuser/src/node_modules/micro/lib/server.js:133:7)
    at sendError (/home/nowuser/src/node_modules/micro/lib/server.js:143:5)
    at Promise.then.catch.err (/home/nowuser/src/node_modules/micro/lib/server.js:37:19)
    at tryCatcher (/home/nowuser/src/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/home/nowuser/src/node_modules/bluebird/js/release/promise.js:512:31)
    at Promise._settlePromise (/home/nowuser/src/node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/home/nowuser/src/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/home/nowuser/src/node_modules/bluebird/js/release/promise.js:689:18)
    at Async._drainQueue (/home/nowuser/src/node_modules/bluebird/js/release/async.js:133:16)
    at Async._drainQueues (/home/nowuser/src/node_modules/bluebird/js/release/async.js:143:10)
    at Immediate.Async.drainQueues (/home/nowuser/src/node_modules/bluebird/js/release/async.js:17:14)
    at runCallback (timers.js:800:20)
    at tryOnImmediate (timers.js:762:5)
    at processImmediate [as _immediateCallback] (timers.js:733:5)
```

  </p>
</details>


The trace leaves no indication where it could have happened as the trace is coming from some async call in micro & bluebird.

I looked at `micro-api` as that might have been the cause, and noticed it was deprecated and suggesting `microrouter` instead. After changing to `microrouter`, I honestly think `micro-api` was better.

* The `/*` route is basically a 404 route. Without it, `microrouter` never replies (no default 404 handler). pedronauck/micro-router#18
* The `(.gif)(/)` "hack" is to support `/cats.gif` and `/cats/` to be backwards compatable. snd/url-pattern#38 snd/url-pattern#39

[logs]: https://zeit.co/jxom/micro-giphy-translate/jteiepcarb/logs